### PR TITLE
feat: add Delete read button to clear all read notifications

### DIFF
--- a/backend/routes/notifications.py
+++ b/backend/routes/notifications.py
@@ -162,6 +162,27 @@ async def mark_all_notifications_as_read(
     return {"message": "All notifications marked as read"}
 
 
+@router.delete("/notifications/read")
+async def delete_all_read_notifications(
+    x_user_role: Optional[str] = Header(None),
+    x_user_name: Optional[str] = Header(None)
+):
+    """
+    Delete all notifications that have been read
+    Only deletes read notifications, unread ones are kept
+    """
+    notifications = load_notifications()
+    
+    # Keep only unread notifications
+    unread_notifications = [n for n in notifications if not n.get("isRead", False)]
+    deleted_count = len(notifications) - len(unread_notifications)
+    
+    # Save
+    save_notifications(unread_notifications)
+    
+    return {"message": f"{deleted_count} read notifications deleted"}
+
+
 @router.delete("/notifications/{notification_id}")
 async def delete_notification(
     notification_id: str,

--- a/components/NotificationCenter.tsx
+++ b/components/NotificationCenter.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Bell, Check, CheckCheck, X, AlertCircle } from 'lucide-react';
 import { Notification, NotificationType } from '../types';
-import { markNotificationAsRead, markAllNotificationsAsRead, deleteNotification } from '../services/apiService';
+import { markNotificationAsRead, markAllNotificationsAsRead, deleteNotification, deleteAllReadNotifications } from '../services/apiService';
 import { getUnreadCount } from '../services/notificationService';
 
 interface NotificationCenterProps {
@@ -101,6 +101,18 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({
     }
   };
 
+  const handleDeleteAllRead = async () => {
+    setIsProcessing(true);
+    try {
+      await deleteAllReadNotifications();
+      onNotificationsUpdate();
+    } catch (error) {
+      console.error('Failed to delete read notifications:', error);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
   const handleDelete = async (notificationId: string, e: React.MouseEvent) => {
     e.stopPropagation();
     setIsProcessing(true);
@@ -154,15 +166,26 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({
                   </span>
                 )}
               </div>
-              {notifications.length > 0 && unreadCount > 0 && (
-                <button
-                  onClick={handleMarkAllAsRead}
-                  disabled={isProcessing}
-                  className="text-xs text-teal-600 hover:text-teal-700 font-medium transition-colors disabled:opacity-50 px-3 py-1.5 hover:bg-white/50 rounded-lg"
-                >
-                  {isProcessing ? 'Marking...' : 'Mark all read'}
-                </button>
-              )}
+              <div className="flex items-center gap-2">
+                {notifications.length > 0 && unreadCount > 0 && (
+                  <button
+                    onClick={handleMarkAllAsRead}
+                    disabled={isProcessing}
+                    className="text-xs text-teal-600 hover:text-teal-700 font-medium transition-colors disabled:opacity-50 px-2 py-1.5 hover:bg-white/50 rounded-lg"
+                  >
+                    Mark all read
+                  </button>
+                )}
+                {notifications.length > 0 && notifications.some(n => n.isRead) && (
+                  <button
+                    onClick={handleDeleteAllRead}
+                    disabled={isProcessing}
+                    className="text-xs text-red-500 hover:text-red-600 font-medium transition-colors disabled:opacity-50 px-2 py-1.5 hover:bg-red-50 rounded-lg"
+                  >
+                    Delete read
+                  </button>
+                )}
+              </div>
             </div>
 
             {/* Notification List */}

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -416,6 +416,17 @@ export const deleteNotification = async (notificationId: string): Promise<void> 
   }
 };
 
+export const deleteAllReadNotifications = async (): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/notifications/read`, {
+    method: 'DELETE',
+    headers: getAuthHeaders(),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to delete read notifications');
+  }
+};
+
 // --- Health Check ---
 export const checkHealth = async (): Promise<boolean> => {
   try {


### PR DESCRIPTION
- Add DELETE /api/notifications/read endpoint in backend
- Add deleteAllReadNotifications() function in apiService
- Add Delete read button in NotificationCenter header
- Button only appears when there are read notifications
- Unread notifications are preserved when deleting